### PR TITLE
Add Modal to {model deployment, AI workspaces}

### DIFF
--- a/ai-enablement-stack.json
+++ b/ai-enablement-stack.json
@@ -45,6 +45,14 @@
               "hidden": "true",
               "github": "",
               "x": "@morph_labs"
+            },
+            {
+              "name": "Modal",
+              "description": "Modal offers a serverless cloud platform for AI and ML applications that enables developers to deploy and scale workloads instantly with simple Python code, featuring high-performance GPU infrastructure and pay-per-use pricing.",
+              "logo": "./public/images/modal.svg",
+              "link": "https://modal.com/",
+              "github": "",
+              "x": "@modal_labs"
             }
           ]
         },
@@ -184,6 +192,14 @@
               "link": "https://openrouter.ai/",
               "github": "",
               "x": "@OpenRouterAI"
+            },
+            {
+              "name": "Modal",
+              "description": "Modal offers a serverless cloud platform for AI and ML applications that enables developers to deploy and scale workloads instantly with simple Python code, featuring high-performance GPU infrastructure and pay-per-use pricing.",
+              "logo": "./public/images/modal.svg",
+              "link": "https://modal.com/",
+              "github": "",
+              "x": "@modal_labs"
             }
           ]
         },


### PR DESCRIPTION
Modal is currently listed in _Training & Fine-Tuning_ but also the platform has first class support in the _Model Deployment_ and _AI Workspaces_ categories.

* Model Deployment -> https://modal.com/use-cases/image-video-3d, https://modal.com/use-cases/language-models
* AI Workspaces -> https://modal.com/use-cases/sandboxes

(Also I was tempted to vary the `description` field across categories to tailor them for the category, but wasn't sure that this was desired.)